### PR TITLE
Draw timer on screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.suo
 *.user
 Debug/
+Release/

--- a/DDRMenu/DDRMenu.cpp
+++ b/DDRMenu/DDRMenu.cpp
@@ -80,7 +80,11 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
     while(true) {
         io->Tick();
         menu->Tick();
-        display->Tick();
+        
+        if(display->Tick(menu->SecondsLeft()))
+        {
+            menu->ResetTimeout();
+        }
 
         /* See if somebody killed the display window */
         if (display->WasClosed())
@@ -127,7 +131,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
         HANDLE hBat = CreateFileA(tempPath, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
 
         char command[MAX_GAME_LOCATION_LENGTH + 128];
-        sprintf_s(command, MAX_GAME_LOCATION_LENGTH + 128, "ping 127.0.0.1 -n 5 -w 1000 > nul\r\n%s\r\n", path);
+        sprintf_s(command, MAX_GAME_LOCATION_LENGTH + 128, "echo off\r\ncls\r\nping 127.0.0.1 -n 5 -w 1000 > nul\r\n%s\r\n", path);
         DWORD bytesWritten;
         WriteFile(hBat, command, strlen(command), &bytesWritten, NULL);
         CloseHandle(hBat);

--- a/DDRMenu/DDRMenu.vcproj
+++ b/DDRMenu/DDRMenu.vcproj
@@ -118,7 +118,7 @@
 				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE"
 				RuntimeLibrary="2"
 				EnableFunctionLevelLinking="true"
-				UsePrecompiledHeader="2"
+				UsePrecompiledHeader="0"
 				WarningLevel="3"
 				DebugInformationFormat="3"
 			/>
@@ -133,9 +133,10 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
+				AdditionalDependencies="Setupapi.lib"
 				LinkIncremental="1"
 				GenerateDebugInformation="true"
-				SubSystem="1"
+				SubSystem="2"
 				OptimizeReferences="2"
 				EnableCOMDATFolding="2"
 				TargetMachine="1"

--- a/DDRMenu/Display.h
+++ b/DDRMenu/Display.h
@@ -18,7 +18,7 @@ public:
     Display(HINSTANCE hInstance, IO *io, Menu *mInst);
     ~Display();
 
-    void Tick();
+    bool Tick(unsigned int newTimeRemain);
     bool WasClosed();
 
     unsigned int GetSelectedItem();

--- a/DDRMenu/IO.h
+++ b/DDRMenu/IO.h
@@ -57,6 +57,9 @@
 
 #define LIGHT_BASS_NEONS 0x00400000
 
+//time for watchdog to be reset every time
+#define WATCHDOG_FEED_S 180
+
 typedef struct {
     unsigned int slot1;
     unsigned int slot2;
@@ -77,6 +80,7 @@ public:
     void SetLights(unsigned int lights);
     void LightOn(unsigned int light);
     void LightOff(unsigned int light);
+    void FeedWatchdog();
 private:
     HANDLE p3io;
     HANDLE extio;


### PR DESCRIPTION
Minor changes to assist with communicating state machine state to users.

- draws timer on bottom right hand side of screen
- timer resets on every user interaction (prevents someone panicking to make a selection)
- added echo off/clear to launch command to clean up visually the game executing.
- modified vcproj to compile in a fresh install of vs2018 in a vm (setupapi.lib and precompiled headers)

Tested in chimera 945 setup on real hardware.